### PR TITLE
Add VectorMixin base class

### DIFF
--- a/tree_math/__init__.py
+++ b/tree_math/__init__.py
@@ -20,7 +20,7 @@ from tree_math._src.func_wrappers import (
     wrap,
     unwrap,
 )
-from tree_math._src.vector import Vector, VectorBase
+from tree_math._src.vector import Vector, VectorMixin
 import tree_math.numpy
 
 __version__ = '0.1.0'

--- a/tree_math/__init__.py
+++ b/tree_math/__init__.py
@@ -20,7 +20,7 @@ from tree_math._src.func_wrappers import (
     wrap,
     unwrap,
 )
-from tree_math._src.vector import Vector
+from tree_math._src.vector import Vector, VectorBase
 import tree_math.numpy
 
 __version__ = '0.1.0'

--- a/tree_math/_src/numpy_test.py
+++ b/tree_math/_src/numpy_test.py
@@ -49,7 +49,7 @@ class NumpyTest(test_util.TestCase):
     actual = tnp.where(True, 1, 2)
     self.assertTreeEqual(actual, expected, check_dtypes=False)
     with self.assertRaisesRegex(
-        TypeError, "non-tree_math.Vector argument is not a scalar",
+        TypeError, "non-tree_math.VectorBase argument is not a scalar",
     ):
       tnp.where(True, jnp.array([1, 2]), 3)
 

--- a/tree_math/_src/numpy_test.py
+++ b/tree_math/_src/numpy_test.py
@@ -49,7 +49,7 @@ class NumpyTest(test_util.TestCase):
     actual = tnp.where(True, 1, 2)
     self.assertTreeEqual(actual, expected, check_dtypes=False)
     with self.assertRaisesRegex(
-        TypeError, "non-tree_math.VectorBase argument is not a scalar",
+        TypeError, "non-tree_math.VectorMixin argument is not a scalar",
     ):
       tnp.where(True, jnp.array([1, 2]), 3)
 

--- a/tree_math/_src/vector.py
+++ b/tree_math/_src/vector.py
@@ -53,14 +53,14 @@ def _argnums_partial(f, args, static_argnums):
 
 def broadcasting_map(func, *args):
   """Like tree_map, but scalar arguments are broadcast to all leaves."""
-  static_argnums = [i for i, x in enumerate(args) if not isinstance(x, Vector)]
+  static_argnums = [i for i, x in enumerate(args) if not isinstance(x, VectorBase)]
   func2, vector_args = _argnums_partial(func, args, static_argnums)
   for arg in args:
-    if not isinstance(arg, Vector):
+    if not isinstance(arg, VectorBase):
       shape = jnp.shape(arg)
       if shape:
         raise TypeError(
-            f"non-tree_math.Vector argument is not a scalar: {arg!r}"
+            f"non-tree_math.VectorBase argument is not a scalar: {arg!r}"
         )
   if not vector_args:
     return func2()  # result is a scalar
@@ -112,8 +112,8 @@ def dot(left, right, *, precision="highest"):
   Returns:
     Resulting dot product (scalar).
   """
-  if not isinstance(left, Vector) or not isinstance(right, Vector):
-    raise TypeError("matmul arguments must both be tree_math.Vector objects")
+  if not isinstance(left, VectorBase) or not isinstance(right, VectorBase):
+    raise TypeError("matmul arguments must both be tree_math.VectorBase objects")
 
   def _vector_dot(a, b):
     return jnp.dot(jnp.ravel(a), jnp.ravel(b), precision=precision)
@@ -206,7 +206,7 @@ class VectorBase:
     return jnp.asarray(list(parts)).max()
 
 @tree_util.register_pytree_node_class
-class Vector:
+class Vector(VectorBase):
   """A wrapper for treating an arbitrary pytree as a 1D vector."""
 
   def __init__(self, tree):

--- a/tree_math/_src/vector.py
+++ b/tree_math/_src/vector.py
@@ -123,7 +123,7 @@ def dot(left, right, *, precision="highest"):
   return functools.reduce(operator.add, parts)
 
 class VectorBase:
-  """A wrapper for treating an arbitrary pytree as a 1D vector."""
+  """A mixin class that adds a 1D vector-like behaviour to any custom pytree class."""
 
   @property
   def size(self):

--- a/tree_math/_src/vector.py
+++ b/tree_math/_src/vector.py
@@ -64,7 +64,7 @@ def broadcasting_map(func, *args):
         )
   if not vector_args:
     return func2()  # result is a scalar
-  _flatten_together(*[arg.tree for arg in vector_args])  # check shapes
+  _flatten_together(*[arg for arg in vector_args])  # check shapes
   return tree_util.tree_map(func2, *vector_args)
 
 
@@ -118,37 +118,16 @@ def dot(left, right, *, precision="highest"):
   def _vector_dot(a, b):
     return jnp.dot(jnp.ravel(a), jnp.ravel(b), precision=precision)
 
-  (left_values, right_values), _ = _flatten_together(left.tree, right.tree)
+  (left_values, right_values), _ = _flatten_together(left, right)
   parts = map(_vector_dot, left_values, right_values)
   return functools.reduce(operator.add, parts)
 
-
-@tree_util.register_pytree_node_class
-class Vector:
+class VectorBase:
   """A wrapper for treating an arbitrary pytree as a 1D vector."""
-
-  def __init__(self, tree):
-    self._tree = tree
-
-  @property
-  def tree(self):
-    return self._tree
-
-  # TODO(shoyer): consider casting to a common dtype?
-
-  def __repr__(self):
-    return f"tree_math.Vector({self._tree!r})"
-
-  def tree_flatten(self):
-    return (self.tree,), None
-
-  @classmethod
-  def tree_unflatten(cls, _, args):
-    return cls(*args)
 
   @property
   def size(self):
-    values = tree_util.tree_leaves(self.tree)
+    values = tree_util.tree_leaves(self)
     return sum(jnp.size(value) for value in values)
 
   def __len__(self):
@@ -164,7 +143,7 @@ class Vector:
 
   @property
   def dtype(self):
-    values = tree_util.tree_leaves(self.tree)
+    values = tree_util.tree_leaves(self)
     return jnp.result_type(*values)
 
   # comparison
@@ -225,3 +204,28 @@ class Vector:
   def max(self):
     parts = map(jnp.max, tree_util.tree_leaves(self))
     return jnp.asarray(list(parts)).max()
+
+@tree_util.register_pytree_node_class
+class Vector:
+  """A wrapper for treating an arbitrary pytree as a 1D vector."""
+
+  def __init__(self, tree):
+    self._tree = tree
+
+  @property
+  def tree(self):
+    return self._tree
+
+  # TODO(shoyer): consider casting to a common dtype?
+
+  def __repr__(self):
+    return f"tree_math.Vector({self._tree!r})"
+
+  def tree_flatten(self):
+    return (self._tree,), None
+
+  @classmethod
+  def tree_unflatten(cls, _, args):
+    return cls(*args)
+
+  

--- a/tree_math/_src/vector_test.py
+++ b/tree_math/_src/vector_test.py
@@ -58,7 +58,7 @@ class VectorTest(test_util.TestCase):
     self.assertTreeEqual(vector + 1, expected, check_dtypes=True)
     self.assertTreeEqual(1 + vector, expected, check_dtypes=True)
     with self.assertRaisesRegex(
-        TypeError, "non-tree_math.VectorBase argument is not a scalar",
+        TypeError, "non-tree_math.VectorMixin argument is not a scalar",
     ):
       vector + jnp.ones((3,))  # pylint: disable=expression-not-assigned
 
@@ -123,7 +123,7 @@ class VectorTest(test_util.TestCase):
     self.assertAllClose(actual, expected)
 
     with self.assertRaisesRegex(
-        TypeError, "matmul arguments must both be tree_math.VectorBase objects",
+        TypeError, "matmul arguments must both be tree_math.VectorMixin objects",
     ):
       vector1 @ jnp.ones((7,))  # pylint: disable=expression-not-assigned
 
@@ -151,7 +151,7 @@ class VectorTest(test_util.TestCase):
   def test_custom_class(self):
     
     @tree_util.register_pytree_node_class
-    class CustomVector(tm.VectorBase):
+    class CustomVector(tm.VectorMixin):
 
       def __init__(self, a: int, b: float):
         self.a = a

--- a/tree_math/_src/vector_test.py
+++ b/tree_math/_src/vector_test.py
@@ -148,6 +148,34 @@ class VectorTest(test_util.TestCase):
     self.assertTreeEqual(vector.min(), 1, check_dtypes=False)
     self.assertTreeEqual(vector.max(), 4, check_dtypes=False)
 
+  def test_custom_class(self):
+    
+    @tree_util.register_pytree_node_class
+    class CustomVector(tm.VectorBase):
+
+      def __init__(self, a: int, b: float):
+        self.a = a
+        self.b = b
+
+      def tree_flatten(self):
+        return (self.a, self.b), None
+
+      @classmethod
+      def tree_unflatten(cls, _, args):
+        return cls(*args)
+
+    v1 = CustomVector(1, 2.0)
+    v2 = v1 + 3
+    assert isinstance(v2, CustomVector)
+    assert v2.a == 4
+    assert np.isclose(v2.b, 5.0)
+
+    v3 = v2 + v1
+    assert isinstance(v3, CustomVector)
+    assert v3.a == 5
+    assert np.isclose(v3.b, 7.0)
+        
+
 
 if __name__ == "__main__":
   absltest.main()

--- a/tree_math/_src/vector_test.py
+++ b/tree_math/_src/vector_test.py
@@ -166,14 +166,10 @@ class VectorTest(test_util.TestCase):
 
     v1 = CustomVector(1, 2.0)
     v2 = v1 + 3
-    assert isinstance(v2, CustomVector)
-    assert v2.a == 4
-    assert np.isclose(v2.b, 5.0)
+    self.assertTreeEqual(v2, CustomVector(4, 5.0), check_dtypes=True)
 
     v3 = v2 + v1
-    assert isinstance(v3, CustomVector)
-    assert v3.a == 5
-    assert np.isclose(v3.b, 7.0)
+    self.assertTreeEqual(v3, CustomVector(5, 7.0), check_dtypes=True)
         
 
 

--- a/tree_math/_src/vector_test.py
+++ b/tree_math/_src/vector_test.py
@@ -58,7 +58,7 @@ class VectorTest(test_util.TestCase):
     self.assertTreeEqual(vector + 1, expected, check_dtypes=True)
     self.assertTreeEqual(1 + vector, expected, check_dtypes=True)
     with self.assertRaisesRegex(
-        TypeError, "non-tree_math.Vector argument is not a scalar",
+        TypeError, "non-tree_math.VectorBase argument is not a scalar",
     ):
       vector + jnp.ones((3,))  # pylint: disable=expression-not-assigned
 
@@ -123,7 +123,7 @@ class VectorTest(test_util.TestCase):
     self.assertAllClose(actual, expected)
 
     with self.assertRaisesRegex(
-        TypeError, "matmul arguments must both be tree_math.Vector objects",
+        TypeError, "matmul arguments must both be tree_math.VectorBase objects",
     ):
       vector1 @ jnp.ones((7,))  # pylint: disable=expression-not-assigned
 


### PR DESCRIPTION
As discussed in #3 this PR adds the `VectorBase` class which both contains the base vector logic and can act as a mixin that can be applied to any pytree class. The `Vector` class is now a simple pytree container that inherits from `VectorBase`.

I've use `VectorBase` here as it reads better but we can still consider the `VectorMixin` option. 

Pending:
- [x] Add a test to check that this works with classes other than `Vector`.